### PR TITLE
Install shell completion scripts

### DIFF
--- a/Formula/jx.rb
+++ b/Formula/jx.rb
@@ -8,6 +8,14 @@ class Jx < Formula
 
   def install
     bin.install name
+
+    output = Utils.popen_read("SHELL=bash #{bin}/jx completion bash")
+    (bash_completion/"jx").write output
+
+    output = Utils.popen_read("SHELL=zsh #{bin}/jx completion zsh")
+    (zsh_completion/"_jx").write output
+
+    prefix.install_metafiles
   end
 
 end


### PR DESCRIPTION
Use homebrew to install completion scripts. Helps with automatically updating them when updating to a new version, which discourages the pattern of sourcing them with eval in bashrc/zshrc.

Not sure how thoroughly you want this tested, but using my own tap to install and the completion worked out-of-the-box.

```
brew tap kyounger/jx
brew install jx
jx <tab>
```

<img width="577" alt="image" src="https://user-images.githubusercontent.com/197920/52879477-d5f99c80-3124-11e9-97b6-f41b7dd1215c.png">
