### PR TITLE
chore(deps): bump https://github.com/jenkins-x/jx.git from 2.0.583 to 2.0.586

### DIFF
--- a/Formula/jx.rb
+++ b/Formula/jx.rb
@@ -2,10 +2,10 @@
 class Jx < Formula
   desc "A tool to install and interact with Jenkins X on your Kubernetes cluster."
   homepage "https://jenkins-x.io/"
-  version "2.0.583"
+  version "2.0.586"
 
   url "http://github.com/jenkins-x/jx/releases/download/v#{version}/jx-darwin-amd64.tar.gz"
-  sha256 "32e939cff558bd1c9f5a8c2f3154d58269ac3b3244c64c292631a1a4dc8b2074"
+  sha256 "91f31bfadf38aee6b138645e3c72b6a631a4fe0bf51b9db97d62d3f8626bfaf1"
 
   def install
     bin.install name

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jenkins-x/jx](https://github.com/jenkins-x/jx.git) |  | [2.0.583](https://github.com/jenkins-x/jx/releases/tag/v2.0.583) | 
+[jenkins-x/jx](https://github.com/jenkins-x/jx.git) |  | [2.0.586](https://github.com/jenkins-x/jx/releases/tag/v2.0.586) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,5 +3,5 @@ dependencies:
   owner: jenkins-x
   repo: jx
   url: https://github.com/jenkins-x/jx.git
-  version: 2.0.583
-  versionURL: https://github.com/jenkins-x/jx/releases/tag/v2.0.583
+  version: 2.0.586
+  versionURL: https://github.com/jenkins-x/jx/releases/tag/v2.0.586


### PR DESCRIPTION
Update [jenkins-x/jx](https://github.com/jenkins-x/jx.git) from [2.0.583](https://github.com/jenkins-x/jx/releases/tag/v2.0.583) to [2.0.586](https://github.com/jenkins-x/jx/releases/tag/v2.0.586)

Command run was `jx step create pr brew --version 2.0.586 --sha 91f31bfadf38aee6b138645e3c72b6a631a4fe0bf51b9db97d62d3f8626bfaf1 --repo https://github.com/jenkins-x/homebrew-jx.git --src-repo https://github.com/jenkins-x/jx.git`